### PR TITLE
git-ignored mac meta file .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 config.json
+.DS_Store
 .*/


### PR DESCRIPTION
added .DS_Store in .gitignore

.DS_Store is a meta container for macs that allows the Finder to store information such as tags, labels and other forms of metadata. 

Apple (2021). Adjust SMB browsing behavior in macOS. Retrieved from: https://support.apple.com/en-ph/HT208209